### PR TITLE
Add single-page app demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 **Structure that lets love surprise you.**
 
 A beautiful relationship companion app that helps users consistently connect with their romantic partner through small, meaningful actions that feel organic but are scheduled randomly within set time frames.
+
+## Getting Started
+
+Simply open `index.html` in a modern browser to try the demo single-page webapp.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Framework of Us</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Framework of Us</h1>
+        <p class="tagline">Structure that lets love surprise you.</p>
+        <p>We lay the framework. You light the sparks. A love built to last.</p>
+    </header>
+
+    <main>
+        <section id="features">
+            <h2>Key Features</h2>
+            <ul>
+                <li>Smart reminders with natural intervals</li>
+                <li>Personalized suggestions</li>
+                <li>Relationship journal</li>
+                <li>Connection tracker</li>
+                <li>Optional partner sync</li>
+            </ul>
+        </section>
+
+        <section id="suggestion-section">
+            <h2>Today's Inspiration</h2>
+            <p id="suggestion">Click the button below for a random suggestion.</p>
+            <button id="new-suggestion">New Suggestion</button>
+        </section>
+
+        <section id="journal">
+            <h2>Journal</h2>
+            <textarea id="entry" rows="4" placeholder="Write what's on your mind..."></textarea>
+            <br>
+            <button id="save-entry">Save Entry</button>
+            <h3>Previous Entries</h3>
+            <ul id="entries"></ul>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2023 Framework of Us</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,41 @@
+const suggestions = [
+    "Compliment your partner today",
+    "Plan a fun date night",
+    "Send a sweet text message",
+    "Remind them of your first date",
+    "Give them their favorite treat"
+];
+
+function getRandomSuggestion() {
+    const index = Math.floor(Math.random() * suggestions.length);
+    return suggestions[index];
+}
+
+document.getElementById('new-suggestion').addEventListener('click', () => {
+    const suggestion = getRandomSuggestion();
+    document.getElementById('suggestion').textContent = suggestion;
+});
+
+function loadEntries() {
+    const entries = JSON.parse(localStorage.getItem('entries') || '[]');
+    const list = document.getElementById('entries');
+    list.innerHTML = '';
+    entries.forEach(e => {
+        const li = document.createElement('li');
+        li.textContent = e;
+        list.appendChild(li);
+    });
+}
+
+loadEntries();
+
+document.getElementById('save-entry').addEventListener('click', () => {
+    const text = document.getElementById('entry').value.trim();
+    if (text) {
+        const entries = JSON.parse(localStorage.getItem('entries') || '[]');
+        entries.unshift(text);
+        localStorage.setItem('entries', JSON.stringify(entries));
+        document.getElementById('entry').value = '';
+        loadEntries();
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,58 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: linear-gradient(120deg, #ffe0e9, #fff5ee);
+    color: #333;
+}
+
+header {
+    text-align: center;
+    padding: 2rem;
+    background-color: #ffccd5;
+}
+
+.tagline {
+    font-size: 1.2rem;
+    font-style: italic;
+}
+
+main {
+    padding: 1rem;
+    max-width: 600px;
+    margin: auto;
+}
+
+section {
+    margin-bottom: 2rem;
+    background-color: #ffffffcc;
+    padding: 1rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+button {
+    background-color: #ff8da1;
+    border: none;
+    padding: 0.5rem 1rem;
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #ff5b79;
+}
+
+textarea {
+    width: 100%;
+    padding: 0.5rem;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+}
+
+footer {
+    text-align: center;
+    padding: 1rem;
+    background-color: #ffccd5;
+}


### PR DESCRIPTION
## Summary
- create basic HTML demo showing key app concept
- add simple pastel styles
- implement random suggestion generator and journal storage
- document how to try the page

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_688c3c7588a4832aa1f57703f930a93b